### PR TITLE
Fix news articles not respecting publish and expiration dates (closes #25)

### DIFF
--- a/app/content/routes.py
+++ b/app/content/routes.py
@@ -694,10 +694,18 @@ def view_post(post_id):
     try:
         from flask import abort
         
-        # Get post by ID
-        post = db.session.get(Post, post_id)
+        today = date.today()
+        
+        # Get post by ID and validate publish/expire dates
+        post = db.session.scalar(
+            sa.select(Post).where(
+                Post.id == post_id,
+                Post.publish_on <= today,   # Only show posts that should be published
+                Post.expires_on >= today    # Only show posts that haven't expired
+            )
+        )
         if not post:
-            current_app.logger.error(f"Post not found with ID: {post_id}")
+            current_app.logger.error(f"Post not found or not available with ID: {post_id}")
             abort(404)
         
         current_app.logger.info(f"Found post: {post.title}, HTML file: {post.html_filename}")

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -23,20 +23,22 @@ def index():
     try:
         today = date.today()
         
-        # Fetch pinned posts (posts with pin_until date >= today)
+        # Fetch pinned posts (posts with pin_until date >= today and within publish/expire window)
         pinned_posts = db.session.scalars(
             sa.select(Post).where(
-                Post.expires_on >= today,
-                Post.pin_until >= today
+                Post.publish_on <= today,   # Only show posts that should be published
+                Post.expires_on >= today,   # Only show posts that haven't expired
+                Post.pin_until >= today     # Only show posts that are still pinned
             )
             .order_by(Post.publish_on.desc())
         ).all()
         
-        # Fetch non-pinned posts (posts without pin_until or pin_until < today)
+        # Fetch non-pinned posts (posts without pin_until or pin_until < today and within publish/expire window)
         non_pinned_posts = db.session.scalars(
             sa.select(Post).where(
-                Post.expires_on >= today,
-                sa.or_(Post.pin_until < today, Post.pin_until == None)
+                Post.publish_on <= today,                                    # Only show posts that should be published
+                Post.expires_on >= today,                                    # Only show posts that haven't expired
+                sa.or_(Post.pin_until < today, Post.pin_until == None)      # Only non-pinned posts
             )
             .order_by(Post.publish_on.desc())
             .limit(5)  # Show 5 recent non-pinned posts


### PR DESCRIPTION
## Summary
- Fixed news articles displaying without proper respect for publish_on and expires_on dates
- Added proper date filtering to both main page news display and individual post viewing
- Ensured articles only display within their configured publication window

## Problem Solved
News articles were displaying regardless of their configured publication dates:
- **Future Articles**: Posts with publish_on > today were shown prematurely
- **Expired Articles**: Posts with expires_on < today continued to display
- **Individual Posts**: Direct post URLs bypassed all date validation
- **Inconsistent Behavior**: No systematic date filtering across the content system

## Root Cause Analysis
### Main Page Issues (`/app/main/routes.py`)
- Pinned posts query only filtered by `expires_on >= today` and `pin_until >= today`
- Non-pinned posts query only filtered by `expires_on >= today`  
- **Missing**: `publish_on <= today` filter in both queries
- Result: Future posts appeared immediately instead of waiting for publish date

### Individual Post Issues (`/app/content/routes.py`)
- `view_post()` route used simple `db.session.get(Post, post_id)` lookup
- **Missing**: All date validation for individual post access
- Result: Direct URLs could access future or expired posts

## Technical Changes

### Main Page Date Filtering
```python
# Before: Missing publish_on filter
Post.expires_on >= today,
Post.pin_until >= today

# After: Complete date window validation  
Post.publish_on <= today,   # Only show posts that should be published
Post.expires_on >= today,   # Only show posts that haven't expired
Post.pin_until >= today     # Only show posts that are still pinned
```

### Individual Post Date Filtering
```python
# Before: No date validation
post = db.session.get(Post, post_id)

# After: Date-filtered query
post = db.session.scalar(
    sa.select(Post).where(
        Post.id == post_id,
        Post.publish_on <= today,   # Only show posts that should be published
        Post.expires_on >= today    # Only show posts that haven't expired
    )
)
```

## Test Plan
- [x] Created comprehensive test script with 4 scenarios:
  - Posts published today → Should be visible ✅
  - Posts published yesterday → Should be visible ✅  
  - Posts scheduled for tomorrow → Should be hidden ✅
  - Posts expired yesterday → Should be hidden ✅
- [x] Verified main page filtering works correctly for both pinned and non-pinned posts
- [x] Verified individual post view properly blocks access to future/expired content
- [x] Confirmed existing valid posts continue to display without issues
- [x] Tested edge cases with posts at exact date boundaries

## Acceptance Criteria Met
- [x] Articles only display between "Publish on" and "Expires On" dates
- [x] Proper date filtering applied in all content queries  
- [x] Future articles remain hidden until publish date
- [x] Expired articles are automatically hidden after expiration
- [x] Individual post URLs respect same date validation rules
- [x] No breaking changes to existing functionality
- [x] Consistent behavior across main page and post detail views

## Content Lifecycle Behavior
**Publication Window**: Posts are visible when `current_date >= publish_on AND current_date <= expires_on`

- **Before Publish Date**: Post exists in database but is hidden from public view
- **During Active Period**: Post displays normally on main page and is accessible via direct URL
- **After Expiration**: Post automatically disappears from public view but remains in database

## Files Changed
- `app/main/routes.py` - Added publish_on filter to both pinned and non-pinned post queries
- `app/content/routes.py` - Added date validation to individual post view route

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)